### PR TITLE
add osmnx

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,10 @@ Are you a Hackbright alumna or student?
 
 - [scikit-learn](https://scikit-learn.org/stable/) &mdash;  A free software machine learning library for the Python programming language
 
+## Graphs
+
+- [osmnx](https://osmnx.readthedocs.io/en/stable/) &mdash; retrieve, model, analyze, and visualize street networks from OpenStreetMap. 
+
 # ✨ JavaScript
 
 ## Utilities


### PR DESCRIPTION
- **Section modified:** added a `Graphs` section. 
- **Graduating class:** June 2019

#### Why

I added osmnx because it's a super helpful library to get a portion of a real road network to work with. The library is well-documented and provides helpful nodes and edges data frames. 
